### PR TITLE
Support windows platform. (without deploy)

### DIFF
--- a/cfg.py.example.py
+++ b/cfg.py.example.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 import email.headerregistry
+SNOIN_CONFIG = True
 
 SMTP_ID = 'GMAIL ID'
 SMTP_PASSWORD = 'SUPER SECRET'
 MAIL_LISTENERS = [
-    email.headerregistry.Address('name', 'no-reply@snoin.com'),
+    email.headerregistry.Address('이름', 'no-reply@snoin.com'),
 ]

--- a/cfg.py.example.py
+++ b/cfg.py.example.py
@@ -3,5 +3,5 @@ import email.headerregistry
 SMTP_ID = 'GMAIL ID'
 SMTP_PASSWORD = 'SUPER SECRET'
 MAIL_LISTENERS = [
-    email.headerregistry.Address('이름', 'no-reply@snoin.com'),
+    email.headerregistry.Address('name', 'no-reply@snoin.com'),
 ]

--- a/cfg.py.example.py
+++ b/cfg.py.example.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import email.headerregistry
+
 SNOIN_CONFIG = True
 
 SMTP_ID = 'GMAIL ID'

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ install_requires = {
     'Click >= 5.1',
     # API
     'requests >= 2.8.1',
-    # Deploy
-    'uwsgi >= 2.0.11.2',
+}
+
+extras_require = {
+    "deploy": [
+        # Deploy
+        'uwsgi >= 2.0.11.2',
+    ],
 }
 
 setup(
@@ -18,6 +23,7 @@ setup(
     url='http://snoin.com',
     packages=find_packages(),
     install_requires=install_requires,
+    extras_require=extras_require,
     entry_points={
         'console_scripts': [
             'snoin-web=snoin.cli:main',

--- a/snoin/config.py
+++ b/snoin/config.py
@@ -1,6 +1,6 @@
 import pathlib
-import sys
 import runpy
+import sys
 
 def error(msgfmt, *args):
     msg = msgfmt.format(*args)

--- a/snoin/config.py
+++ b/snoin/config.py
@@ -1,21 +1,22 @@
 import pathlib
 import sys
+import runpy
 
+def error(msgfmt, *args):
+    msg = msgfmt.format(*args)
+    print(msg, file=sys.stderr)
+    raise SystemError(1)
 
 def load(file: pathlib.Path) -> dict:
     if not file.exists():
-        print('존재하지 않는 파일', file=sys.stderr)
-        raise SystemError(1)
+        error('존재하지 않는 파일')
     if not file.is_file():
-        print('파일이 아님', file=sys.stderr)
-        raise SystemError(1)
+        error('파일이 아님')
     if file.suffix != '.py':
-        print('python 파일만 처리 가능', file=sys.stderr)
-        raise SystemError(1)
+        error('python 파일만 처리 가능')
 
-    config = {}
-
-    with file.open() as f:
-        exec(compile(f.read(), file.name, 'exec'), config)
+    config = runpy.run_path(file.name, run_name="<snoin.config>")
+    if not config.get("SNOIN_CONFIG"):
+        error('snoin config 파일만 처리 가능 (SNOIN_CONFIG is unset)')
 
     return config


### PR DESCRIPTION
uwsgi 모듈은 리눅스 운영체제에서만 사용가능하고, 없어도 개발하는데에는 지장이 없습니다.

차후 윈도우를 지원하지 않는 모듈을 추가해야 될 필요성이 있을 때에는 어쩔수 없겠지만 현재는 실제 운영을 제외한 개발용 서버를 돌리는데에는 필요하지 않아서 변경했습니다.
