### PR TITLE
README에서 travis 빌드 상태 보여주기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 snoin.com
 =========
 
+[![Build Status](https://travis-ci.org/Snoin/snoin.com.svg?branch=master)](https://travis-ci.org/Snoin/snoin.com)
+
 스노인 공식 사이트입니다!
 
 설치


### PR DESCRIPTION
README.md(프로젝트 메인 페이지)에서 Travis 빌드 상태를 볼 수 있도록 배너를 추가했습니다.