### PR TITLE
Lint 개선

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 - '[ $TRAVIS_PYTHON_VERSION = "3.5" ] && import-order snoin ./snoin ./tests'
 - yarn run lint-js
 - yarn run lint-style
+- gixy deploy/nginx.conf
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - 3.5
+- 3.6
 addons:
   firefox: latest
 sudo: false
@@ -19,8 +20,8 @@ script:
 - yarn run build-product
 - yarn run test-karma-ci
 # lint
-- flake8 ./snoin ./tests
-- '[ $TRAVIS_PYTHON_VERSION = "3.5" ] && import-order snoin ./snoin ./tests'
+- flake8 --ignore I100.I101,I201 ./snoin ./tests
+- '[ $TRAVIS_PYTHON_VERSION = "3.6" ] && flake8 --select I100.I101,I201 ./snoin ./tests'
 - yarn run lint-js
 - yarn run lint-style
 - gixy deploy/nginx.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 - yarn run test-karma-ci
 # lint
 - flake8 --ignore I100.I101,I201 ./snoin ./tests
-- '[ $TRAVIS_PYTHON_VERSION = "3.6" ] && flake8 --select I100.I101,I201 ./snoin ./tests'
+- '[ "$TRAVIS_PYTHON_VERSION" = "3.6" ] && flake8 --select I100.I101,I201 ./snoin ./tests || true'
 - yarn run lint-js
 - yarn run lint-style
 - gixy deploy/nginx.conf

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,8 +28,8 @@ Python
 * indentation으로는 space 4글자를 사용한다.
 * 불필요한 diff 발생을 막기 위해 모든 ``import``\는 알파벳 오름차순(a-z순)으로
   정렬한다. 혹시라도 있을 수 있는 실수를 방지하기 위해
-  import-order_\를 사용하여 import 순서를 강제적으로 통일한다.
-  (단, import-order_\를 사용하는 대상은 테스트 대상이 되는 버전 중
+  flake8-import-order_\를 사용하여 import 순서를 강제적으로 통일한다.
+  (단, flake8-import-order_\를 사용하는 대상은 테스트 대상이 되는 Python 버전 중
   가장 최신 버전만 해당한다)
 * 다른 Third-party 라이브러리와의 연동을 위해 docstring 외의 내용이 있는 모든
   모듈은 ``__all__`` 변수를 항상 작성한다.
@@ -98,7 +98,7 @@ Python
 
 .. _PEP-8: https://www.python.org/dev/peps/pep-0008/
 .. _flake8: https://flake8.readthedocs.org/en/latest/
-.. _import-order: https://pypi.python.org/pypi/import-order/
+.. _flake8-import-order: https://github.com/PyCQA/flake8-import-order/
 
 
 HTML

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,7 +2,6 @@
 set -e
 if git diff --cached --name-only | grep "\.py$" > /dev/null; then
     flake8 ./snoin ./tests
-    import-order snoin ./snoin ./tests
 fi
 if git diff --cached --name-only | grep "\.jsx\{0,1\}$" > /dev/null; then
     yarn run lint-js

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,10 +5,10 @@ if git diff --cached --name-only | grep "\.py$" > /dev/null; then
     import-order snoin ./snoin ./tests
 fi
 if git diff --cached --name-only | grep "\.jsx\{0,1\}$" > /dev/null; then
-    npm run lint-js
+    yarn run lint-js
 fi
 if git diff --cached --name-only | grep "\.s\{0,1\}css$" > /dev/null; then
-    npm run lint-style
+    yarn run lint-style
 fi
 if git diff --cached --name-only | grep "\.conf$" > /dev/null; then
     gixy deploy/*.conf

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -10,3 +10,6 @@ fi
 if git diff --cached --name-only | grep "\.s\{0,1\}css$" > /dev/null; then
     npm run lint-style
 fi
+if git diff --cached --name-only | grep "\.conf$" > /dev/null; then
+    gixy deploy/*.conf
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -10,3 +10,6 @@ fi
 if git diff HEAD master --name-only | grep "\.s\{0,1\}css$" > /dev/null; then
     npm run lint-style
 fi
+if git diff HEAD master --name-only | grep "\.conf$" > /dev/null; then
+    gixy deploy/*.conf
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,10 +5,10 @@ if git diff HEAD master --name-only | grep "\.py$" > /dev/null; then
     import-order snoin ./snoin ./tests
 fi
 if git diff HEAD master --name-only | grep "\.jsx\{0,1\}$" > /dev/null; then
-    npm run lint-js
+    yarn run lint-js
 fi
 if git diff HEAD master --name-only | grep "\.s\{0,1\}css$" > /dev/null; then
-    npm run lint-style
+    yarn run lint-style
 fi
 if git diff HEAD master --name-only | grep "\.conf$" > /dev/null; then
     gixy deploy/*.conf

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -2,7 +2,6 @@
 set -e
 if git diff HEAD master --name-only | grep "\.py$" > /dev/null; then
     flake8 ./snoin ./tests
-    import-order snoin ./snoin ./tests
 fi
 if git diff HEAD master --name-only | grep "\.jsx\{0,1\}$" > /dev/null; then
     yarn run lint-js

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = {
 tests_require = {
     'pytest >= 3.0.5',
     'flake8 >= 3.2.1',
-    'import-order >= 0.0.11',
+    'flake8-import-order >= 0.12',
     'gixy >= 0.1.4',
 }
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ tests_require = {
     'pytest >= 3.0.5',
     'flake8 >= 3.2.1',
     'import-order >= 0.0.11',
+    'gixy >= 0.1.4',
 }
 
 extras_require = {

--- a/snoin/config.py
+++ b/snoin/config.py
@@ -1,6 +1,6 @@
-from email.headerregistry import Address
 import pathlib
 import sys
+from email.headerregistry import Address
 
 import toml
 

--- a/snoin/web/app.py
+++ b/snoin/web/app.py
@@ -1,6 +1,6 @@
+import smtplib
 from email.headerregistry import Address
 from email.message import EmailMessage
-import smtplib
 
 from flask import Flask, jsonify, render_template, request
 

--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -3,6 +3,7 @@ import json
 import smtplib
 
 from flask import url_for
+
 from snoin.web.app import app
 
 


### PR DESCRIPTION
1. [gixy](https://github.com/yandex/gixy)를 사용하여 nginx 설정을 검사합니다.
2. Python용 import order linter로 flake8-import-order를 사용합니다. 이것을 사용하면 기존 사용하던 외부 실행파일을 하나 줄일 수 있습니다.
3. Travis-CI상에서 Python 3.6을 사용하여 테스트합니다.